### PR TITLE
chore(github): update node and pnpm versions

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -14,7 +14,7 @@ jobs:
       contents: write
     with:
       ui-path: "ui"
-      pnpm-version: "11.2.2"
+      pnpm-version: "11.5.0"
       node-version: 24
       java-version: 21
       app-id: app-ncyyngrz

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -91,7 +91,7 @@ jobs:
     uses: halo-sigs/reusable-workflows/.github/workflows/plugin-ci.yaml@574420d846900eb5e6b25af72d43dca475583eac # https://github.com/halo-sigs/reusable-workflows/tree/v4
     with:
       ui-path: "ui"
-      pnpm-version: "11.2.2"
+      pnpm-version: "11.5.0"
       node-version: 24
       java-version: 21
 

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
     "type": "module",
     "engines": {
         "node": ">=24",
-        "pnpm": "^11.2.2"
+        "pnpm": "^11.5.0"
     },
-    "packageManager": "pnpm@11.2.2",
+    "packageManager": "pnpm@11.5.0",
     "scripts": {
         "generate:spec-artifacts": "node scripts/sync-match-rule-spec-artifacts.js",
         "verify:spec-artifacts": "node scripts/sync-match-rule-spec-artifacts.js --check"

--- a/ui/package.json
+++ b/ui/package.json
@@ -58,7 +58,7 @@
   },
   "engines": {
     "node": ">=24",
-    "pnpm": "^11.2.2"
+    "pnpm": "^11.5.0"
   },
-  "packageManager": "pnpm@11.2.2"
+  "packageManager": "pnpm@11.5.0"
 }


### PR DESCRIPTION
This PR updates the repository toolchain versions tracked in:
- `package.json`
- `ui/package.json`
- GitHub workflows that bootstrap Node.js and pnpm directly

Releases are only considered eligible after a 1 day delay, matching the repository's Dependabot cooldown.

Resolved by automation:
- Node.js major: `24`
- pnpm version: `11.5.0`